### PR TITLE
FIx: when transferring to the FeeSharingProxy transferTokens needs to be used

### DIFF
--- a/packages/contracts/contracts/TestContracts/MockFeeSharingProxy.sol
+++ b/packages/contracts/contracts/TestContracts/MockFeeSharingProxy.sol
@@ -2,6 +2,18 @@
 
 pragma solidity 0.6.11;
 
+import "../ZERO/ZEROToken.sol";
+
+interface IFeeSharingProxy {
+	function transferTokens(address _token, uint96 _amount) external;
+}
+
 /// @dev Simple contract that will receive ZERO tokens issued to the SOV stakers.
 ///      see: https://github.com/DistributedCollective/Sovryn-smart-contracts/blob/b5bd57f9003ab95ab36e20859b662f6cd7a195b5/contracts/governance/FeeSharingProxy
-contract MockFeeSharingProxy {}
+contract MockFeeSharingProxy is IFeeSharingProxy {
+
+	function transferTokens(address _token, uint96 _amount) override external {
+		/// Just a fake function to receive the tokens
+		ZEROToken(_token).transferFrom(msg.sender, address(this), _amount);
+	}
+}

--- a/packages/contracts/contracts/ZERO/SovStakersIssuance.sol
+++ b/packages/contracts/contracts/ZERO/SovStakersIssuance.sol
@@ -4,6 +4,13 @@ pragma solidity 0.6.11;
 
 import "./CommunityIssuanceBase.sol";
 
+/// @dev We need to invoke this function in order to deposit the tokens so they
+///      added to the fee distribution logic (and the stake checkpointed)
+interface IFeeSharingProxy {
+	function transferTokens(address _token, uint96 _amount) external;
+}
+
+
 /// @title  This contract holds the Zero tokens to be ditributed to SOV stakers.
 ///         In order to do so it holds the minted ZERO tokens and only allows
 ///         tokens to be transfered if the target address is the SOV staking contract
@@ -12,7 +19,7 @@ import "./CommunityIssuanceBase.sol";
 contract SovStakersIssuance is CommunityIssuanceBase {
 
     /// @dev Tokens can only be sent to the community pot address
-    function _requireBeforeSend(address _to, uint256) internal view override {
+    function _requireBeforeSend(address _to, uint256 _amount) internal view override {
         require(communityPotAddress == _to, "SovStakersIssuance: recipient is not the communityPotAddress");
     }
 
@@ -21,6 +28,10 @@ contract SovStakersIssuance is CommunityIssuanceBase {
     ///         time and sends them to the SOV staking contract.
     function transferToFeeSharingProxy() external {
         uint256 issued = issueZERO();
-        sendZERO(communityPotAddress, issued);
+        IFeeSharingProxy feeSharingProxy = IFeeSharingProxy(communityPotAddress);
+        // Approve the proxy to transfer the tokens
+        zeroToken.approve(communityPotAddress, issued);
+        // This function needs to be invoked in order to checkpoint user's stake
+        feeSharingProxy.transferTokens(address(zeroToken), uint96(issued));
     }
 }


### PR DESCRIPTION
`FeeSharingProxy` requires this function to be called so it checkpoints user staked amounts as stated [here](https://github.com/DistributedCollective/Sovryn-smart-contracts/blob/484cc86a8001c9f15ba3024245b879922e46e48f/contracts/governance/FeeSharingProxy.sol#L1340