### PR TITLE
feat: add aprove_and_call function

### DIFF
--- a/packages/contracts/contracts/Interfaces/IApproveAndCall.sol
+++ b/packages/contracts/contracts/Interfaces/IApproveAndCall.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.11;
+
+/**
+ * @title Interface for contract governance/ApprovalReceiver.sol
+ * @dev Interfaces are used to cast a contract address into a callable instance.
+ */
+interface IApproveAndCall {
+	/**
+	 * @notice Receives approval from SOV token.
+	 * @param _sender The sender of SOV.approveAndCall function.
+	 * @param _amount The amount was approved.
+	 * @param _token The address of token.
+	 * @param _data The data will be used for low level call.
+	 * */
+	function receiveApproval(
+		address _sender,
+		uint256 _amount,
+		address _token,
+		bytes calldata _data
+	) external;
+}

--- a/packages/contracts/contracts/TestContracts/MockApprovalReceiver.sol
+++ b/packages/contracts/contracts/TestContracts/MockApprovalReceiver.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.11;
+import "../Interfaces/IApproveAndCall.sol";
+
+/**
+ * @title Interface for contract governance/ApprovalReceiver.sol
+ * @dev Interfaces are used to cast a contract address into a callable instance.
+ */
+contract MockApprovalReceiver is IApproveAndCall {
+
+    address public sender;
+    uint256 public amount;
+    address public token;
+    bytes public data;
+
+    function receiveApproval(
+        address _sender,
+        uint256 _amount,
+        address _token,
+        bytes calldata _data
+    ) external override {
+        sender = _sender;
+        amount = _amount;
+        token = _token;
+        data = _data;
+    }
+}

--- a/packages/contracts/contracts/ZERO/ZEROToken.sol
+++ b/packages/contracts/contracts/ZERO/ZEROToken.sol
@@ -6,6 +6,7 @@ import "../Dependencies/CheckContract.sol";
 import "../Dependencies/SafeMath.sol";
 import "../Interfaces/IZEROToken.sol";
 import "./ZEROTokenStorage.sol";
+import "../Interfaces/IApproveAndCall.sol";
 
 /**
 * Based upon OpenZeppelin's ERC20 contract:
@@ -123,6 +124,24 @@ contract ZEROToken is ZEROTokenStorage, CheckContract, IZEROToken {
         _requireCallerIsZEROStaking();
         _transfer(_sender, zeroStakingAddress, _amount);
     }
+
+    /**
+	 * @notice Approves and then calls the receiving contract.
+	 * Useful to encapsulate sending tokens to a contract in one call.
+	 * Solidity has no native way to send tokens to contracts.
+	 * ERC-20 tokens require approval to be spent by third parties, such as a contract in this case.
+	 * @param _spender The contract address to spend the tokens.
+	 * @param _amount The amount of tokens to be sent.
+	 * @param _data Parameters for the contract call, such as endpoint signature.
+	 * */
+	function approveAndCall(
+		address _spender,
+		uint256 _amount,
+		bytes memory _data
+	) public {
+		_approve(msg.sender, _spender, _amount);
+		IApproveAndCall(_spender).receiveApproval(msg.sender, _amount, address(this), _data);
+	}
 
     // --- EIP 2612 functionality ---
 


### PR DESCRIPTION
**Updates**

- Add approveAndCall function in Zero token: Approves and then calls the receiving contract.Useful to encapsulate sending tokens to a contract in one call
- Add IApproveAndCall interface: the receivers contracts in approveAndCall have to implement this interface
- Add MockApproveAndCall contract for testing 