### PR TITLE
feat: add cookie consent banner and remove old GA opt-out link

### DIFF
--- a/packages/dev-frontend/public/index.html
+++ b/packages/dev-frontend/public/index.html
@@ -15,7 +15,12 @@
       type="text/css"
     />
     <title>0% interest loans backed by bitcoin | Sovryn</title>
-
+    <style type="text/css">
+      .osano-cm-widget {
+        left: 10px !important;
+      }
+    </style>
+    <script src="https://cmp.osano.com/16BSnVTBY9ksVax/3abc690b-3747-4ba3-b1fb-fcaefd6ab8c1/osano.js"></script>
     <% if (process.env.REACT_APP_GTAG_ID) { %>
     <!-- Google Tag Manager -->
     <script>

--- a/packages/dev-frontend/src/pages/WaitListSignup.tsx
+++ b/packages/dev-frontend/src/pages/WaitListSignup.tsx
@@ -233,27 +233,6 @@ export const WaitListSignup: React.FC = ({ children }) => {
       <Dialog hideCloseIcon open={success} onClose={() => setSuccess(false)}>
         <WaitlistSuccess onClose={() => setSuccess(false)} />
       </Dialog>
-
-      <Link
-        sx={{
-          fontSize: 3,
-          color: "primary",
-          cursor: "pointer",
-          fontWeight: "medium",
-          ":hover": {
-            textDecoration: "underline"
-          },
-          position: "absolute",
-          bottom: 4,
-          left: 4
-        }}
-        href="https://tools.google.com/dlpage/gaoptout"
-        target="_blank"
-        rel="noopener noreferrer"
-        data-action-id="footer-analytics-optout"
-      >
-        Opt-out from Google Analytics
-      </Link>
     </Box>
   );
 };


### PR DESCRIPTION
Adds cookie consent banner as part of changes from this story:
https://sovryn.monday.com/boards/2218344956/pulses/2904957741?doc_id=2908401603