### PR TITLE
fix: broken data-action-id for LOC (#165)

### DIFF
--- a/packages/dev-frontend/src/components/Trove/Adjusting.tsx
+++ b/packages/dev-frontend/src/components/Trove/Adjusting.tsx
@@ -273,7 +273,7 @@ export const Adjusting: React.FC = () => {
             change={troveChange}
             useNueToken={useNueToken}
             maxBorrowingRate={maxBorrowingRate}
-            data-action-id="zero-LOC-confirm"
+            dataActionId="zero-LOC-confirm"
           >
             Confirm
           </TroveAction>

--- a/packages/dev-frontend/src/components/Trove/TroveAction.tsx
+++ b/packages/dev-frontend/src/components/Trove/TroveAction.tsx
@@ -11,6 +11,7 @@ type TroveActionProps = {
   useNueToken: boolean;
   change: Exclude<TroveChange<Decimal>, { type: "invalidCreation" }>;
   maxBorrowingRate: Decimal;
+  dataActionId?: string;
 };
 
 export const TroveAction: React.FC<TroveActionProps> = ({
@@ -18,7 +19,8 @@ export const TroveAction: React.FC<TroveActionProps> = ({
   transactionId,
   change,
   useNueToken,
-  maxBorrowingRate
+  maxBorrowingRate,
+  dataActionId
 }) => {
   const { liquity } = useLiquity();
 
@@ -53,5 +55,9 @@ export const TroveAction: React.FC<TroveActionProps> = ({
 
   const [sendTransaction] = useTransactionFunction(transactionId, troveAction);
 
-  return <Button onClick={sendTransaction}>{children}</Button>;
+  return (
+    <Button onClick={sendTransaction} data-action-id={dataActionId}>
+      {children}
+    </Button>
+  );
 };


### PR DESCRIPTION
Fixes a broken data-action-id used for analytics tracking, when opening/adjusting a Line of Credit in Zero Dashboard